### PR TITLE
Remove the 21 slider FastFlag

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,6 @@ High
 10 = 21
 ```
 
-### 21 Graphics Quality Slider
-```
-{
-    "FFlagCommitToGraphicsQualityFix": "True",
-    "FFlagFixGraphicsQuality": "True"
-}
-```
-
 ### Low Render Distance
 [FRM](#frm-levels)
 ```


### PR DESCRIPTION
Roblox is stupid and they removed the FastFlag for the longer slider back in I think September 2024, so setting this FastFlag won't do anything anymore